### PR TITLE
Fix #12: Add comprehensive unit tests for critical services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,12 +34,14 @@
         "eslint-config-expo": "^9.2.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-native": "^5.0.0",
+        "expo-modules-core": "^2.3.13",
         "globals": "^16.2.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-expo": "~53.0.5",
         "lint-staged": "^16.1.0",
-        "prettier": "^3.5.3"
+        "prettier": "^3.5.3",
+        "react-test-renderer": "^19.1.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -7017,7 +7019,8 @@
     },
     "node_modules/expo-modules-core": {
       "version": "2.3.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.3.13.tgz",
+      "integrity": "sha512-vmKHv7tEo2wUQoYDV6grhsLsQfD3DUnew5Up3yNnOE1gHGQE+zhV1SBYqaPMPB12OvpyD1mlfzGhu6r9PODnng==",
       "dependencies": {
         "invariant": "^2.2.4"
       }
@@ -8877,6 +8880,19 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "webpack": "^5.59.0"
+      }
+    },
+    "node_modules/jest-expo/node_modules/react-test-renderer": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^19.0.0",
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jest-get-type": {
@@ -12142,16 +12158,23 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.0.0",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "react-is": "^19.0.0",
-        "scheduler": "^0.25.0"
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.1.0"
       }
+    },
+    "node_modules/react-test-renderer/node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "dev": true
     },
     "node_modules/recyclerlistview": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -58,12 +58,14 @@
     "eslint-config-expo": "^9.2.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-native": "^5.0.0",
+    "expo-modules-core": "^2.3.13",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-expo": "~53.0.5",
     "lint-staged": "^16.1.0",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "react-test-renderer": "^19.1.0"
   },
   "private": true
 }

--- a/src/services/__tests__/NotificationService.test.js
+++ b/src/services/__tests__/NotificationService.test.js
@@ -1,0 +1,572 @@
+// ABOUTME: Comprehensive unit tests for NotificationService
+// Tests notification sending, preferences, and storage functionality
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NotificationService from '../NotificationService';
+import UserStorageService from '../UserStorageService';
+import { NOTIFICATION_TYPES, NOTIFICATION_PREFERENCES } from '../../constants/UserConstants';
+
+// Mock dependencies
+jest.mock('@react-native-async-storage/async-storage');
+jest.mock('../UserStorageService');
+
+describe('NotificationService', () => {
+  const mockUser = {
+    id: 'user_123',
+    name: 'Test User',
+    notificationPreferences: {
+      global: NOTIFICATION_PREFERENCES.ALL,
+      taskAssigned: true,
+      taskStarted: true,
+      taskCompleted: true,
+      taskOverdue: true,
+      encouragement: true,
+      checkIn: true,
+    },
+  };
+
+  const mockPartnerUser = {
+    id: 'partner_456',
+    name: 'Partner User',
+    notificationPreferences: {
+      global: NOTIFICATION_PREFERENCES.ALL,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset NotificationService state
+    NotificationService.pendingNotifications = [];
+
+    // Default mock implementations
+    AsyncStorage.getItem.mockResolvedValue(null);
+    AsyncStorage.setItem.mockResolvedValue();
+    UserStorageService.getUserById.mockResolvedValue(mockUser);
+  });
+
+  describe('loadNotifications', () => {
+    it('should load notifications from AsyncStorage on initialization', async () => {
+      const storedNotifications = [
+        { id: 'notif_1', toUserId: 'user_123', type: 'task_assigned', read: false },
+        { id: 'notif_2', toUserId: 'user_123', type: 'task_completed', read: true },
+      ];
+
+      AsyncStorage.getItem.mockResolvedValue(JSON.stringify(storedNotifications));
+
+      await NotificationService.loadNotifications();
+
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('@adhdtodo:notifications');
+      expect(NotificationService.pendingNotifications).toEqual(storedNotifications);
+    });
+
+    it('should handle empty storage gracefully', async () => {
+      AsyncStorage.getItem.mockResolvedValue(null);
+
+      await NotificationService.loadNotifications();
+
+      expect(NotificationService.pendingNotifications).toEqual([]);
+    });
+
+    it('should handle storage errors gracefully', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      AsyncStorage.getItem.mockRejectedValue(new Error('Storage error'));
+
+      await NotificationService.loadNotifications();
+
+      expect(consoleError).toHaveBeenCalledWith('Error loading notifications:', expect.any(Error));
+      expect(NotificationService.pendingNotifications).toEqual([]);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('saveNotifications', () => {
+    it('should save notifications to AsyncStorage', async () => {
+      NotificationService.pendingNotifications = [
+        { id: 'notif_1', toUserId: 'user_123', type: 'task_assigned' },
+        { id: 'notif_2', toUserId: 'user_456', type: 'task_completed' },
+      ];
+
+      await NotificationService.saveNotifications();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adhdtodo:notifications',
+        JSON.stringify(NotificationService.pendingNotifications),
+      );
+    });
+
+    it('should limit saved notifications to MAX_NOTIFICATIONS', async () => {
+      // Create more than MAX_NOTIFICATIONS
+      const notifications = [];
+      for (let i = 0; i < NotificationService.MAX_NOTIFICATIONS + 10; i++) {
+        notifications.push({
+          id: `notif_${i}`,
+          toUserId: 'user_123',
+          type: 'task_assigned',
+        });
+      }
+      NotificationService.pendingNotifications = notifications;
+
+      await NotificationService.saveNotifications();
+
+      const savedData = JSON.parse(AsyncStorage.setItem.mock.calls[0][1]);
+      expect(savedData.length).toBe(NotificationService.MAX_NOTIFICATIONS);
+      expect(savedData[0].id).toBe('notif_10'); // Should keep most recent
+    });
+
+    it('should handle save errors gracefully', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      AsyncStorage.setItem.mockRejectedValue(new Error('Save error'));
+
+      NotificationService.pendingNotifications = [{ id: 'notif_1' }];
+      await NotificationService.saveNotifications();
+
+      expect(consoleError).toHaveBeenCalledWith('Error saving notifications:', expect.any(Error));
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('sendNotification', () => {
+    it('should send notification successfully', async () => {
+      const result = await NotificationService.sendNotification(
+        'user_123',
+        NOTIFICATION_TYPES.TASK_ASSIGNED,
+        { taskTitle: 'Test Task' },
+      );
+
+      expect(result).toBe(true);
+      expect(UserStorageService.getUserById).toHaveBeenCalledWith('user_123');
+      expect(NotificationService.pendingNotifications.length).toBe(1);
+
+      const notification = NotificationService.pendingNotifications[0];
+      expect(notification).toMatchObject({
+        toUserId: 'user_123',
+        type: NOTIFICATION_TYPES.TASK_ASSIGNED,
+        data: { taskTitle: 'Test Task' },
+        read: false,
+      });
+      expect(notification.id).toMatch(/^notif_\d+_[a-z0-9]+$/);
+      expect(notification.timestamp).toBeInstanceOf(Date);
+
+      expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('should return false if user not found', async () => {
+      UserStorageService.getUserById.mockResolvedValue(null);
+
+      const result = await NotificationService.sendNotification(
+        'unknown_user',
+        NOTIFICATION_TYPES.TASK_ASSIGNED,
+        {},
+      );
+
+      expect(result).toBe(false);
+      expect(NotificationService.pendingNotifications.length).toBe(0);
+    });
+
+    it('should respect user notification preferences', async () => {
+      const silentUser = {
+        ...mockUser,
+        notificationPreferences: {
+          global: NOTIFICATION_PREFERENCES.SILENT,
+        },
+      };
+      UserStorageService.getUserById.mockResolvedValue(silentUser);
+
+      const result = await NotificationService.sendNotification(
+        'user_123',
+        NOTIFICATION_TYPES.TASK_ASSIGNED,
+        {},
+      );
+
+      expect(result).toBe(false);
+      expect(NotificationService.pendingNotifications.length).toBe(0);
+    });
+
+    it('should handle errors gracefully', async () => {
+      UserStorageService.getUserById.mockRejectedValue(new Error('Database error'));
+
+      const result = await NotificationService.sendNotification(
+        'user_123',
+        NOTIFICATION_TYPES.TASK_ASSIGNED,
+        {},
+      );
+
+      expect(result).toBe(false);
+      expect(NotificationService.pendingNotifications.length).toBe(0);
+    });
+  });
+
+  describe('shouldSendNotification', () => {
+    it('should return false for silent global preference', () => {
+      const user = {
+        notificationPreferences: { global: NOTIFICATION_PREFERENCES.SILENT },
+      };
+
+      const result = NotificationService.shouldSendNotification(
+        user,
+        NOTIFICATION_TYPES.TASK_ASSIGNED,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should only allow critical notifications for important_only preference', () => {
+      const user = {
+        notificationPreferences: { global: NOTIFICATION_PREFERENCES.IMPORTANT_ONLY },
+      };
+
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.TASK_OVERDUE),
+      ).toBe(true);
+      expect(
+        NotificationService.shouldSendNotification(
+          user,
+          NOTIFICATION_TYPES.DEADLINE_CHANGE_REQUEST,
+        ),
+      ).toBe(true);
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.TASK_ASSIGNED),
+      ).toBe(false);
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.ENCOURAGEMENT),
+      ).toBe(false);
+    });
+
+    it('should respect specific notification type preferences', () => {
+      const user = {
+        notificationPreferences: {
+          global: NOTIFICATION_PREFERENCES.ALL,
+          taskAssigned: false,
+          taskStarted: true,
+          taskCompleted: false,
+          taskOverdue: true,
+          encouragement: false,
+          checkIn: true,
+        },
+      };
+
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.TASK_ASSIGNED),
+      ).toBe(false);
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.TASK_STARTED),
+      ).toBe(true);
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.TASK_COMPLETED),
+      ).toBe(false);
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.TASK_OVERDUE),
+      ).toBe(true);
+      expect(
+        NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.ENCOURAGEMENT),
+      ).toBe(false);
+      expect(NotificationService.shouldSendNotification(user, NOTIFICATION_TYPES.CHECK_IN)).toBe(
+        true,
+      );
+    });
+
+    it('should default to true for unknown notification types', () => {
+      const user = {
+        notificationPreferences: { global: NOTIFICATION_PREFERENCES.ALL },
+      };
+
+      const result = NotificationService.shouldSendNotification(user, 'unknown_type');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Task notification methods', () => {
+    const mockTask = {
+      id: 'task_123',
+      title: 'Test Task',
+      assignedTo: 'user_123',
+      assignedBy: 'partner_456',
+      dueDate: new Date('2024-12-31'),
+      priority: 'high',
+      startedAt: new Date(),
+      completedAt: new Date(),
+      timeSpent: 3600,
+      xpEarned: 50,
+    };
+
+    describe('notifyTaskAssigned', () => {
+      it('should send task assigned notification', async () => {
+        const result = await NotificationService.notifyTaskAssigned(mockTask, mockPartnerUser);
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0]).toMatchObject({
+          toUserId: 'user_123',
+          type: NOTIFICATION_TYPES.TASK_ASSIGNED,
+          data: {
+            taskId: 'task_123',
+            taskTitle: 'Test Task',
+            assignedBy: 'Partner User',
+            dueDate: mockTask.dueDate,
+            priority: 'high',
+          },
+        });
+      });
+    });
+
+    describe('notifyTaskStarted', () => {
+      it('should send task started notification to assigner', async () => {
+        const result = await NotificationService.notifyTaskStarted(mockTask, mockUser);
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0]).toMatchObject({
+          toUserId: 'partner_456',
+          type: NOTIFICATION_TYPES.TASK_STARTED,
+          data: {
+            taskId: 'task_123',
+            taskTitle: 'Test Task',
+            startedBy: 'Test User',
+            startedAt: mockTask.startedAt,
+          },
+        });
+      });
+
+      it('should return false if task has no assignedBy', async () => {
+        const taskWithoutAssigner = { ...mockTask, assignedBy: null };
+        const result = await NotificationService.notifyTaskStarted(taskWithoutAssigner, mockUser);
+
+        expect(result).toBe(false);
+        expect(NotificationService.pendingNotifications.length).toBe(0);
+      });
+    });
+
+    describe('notifyTaskCompleted', () => {
+      it('should send task completed notification', async () => {
+        const result = await NotificationService.notifyTaskCompleted(mockTask, mockUser);
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0]).toMatchObject({
+          toUserId: 'partner_456',
+          type: NOTIFICATION_TYPES.TASK_COMPLETED,
+          data: {
+            taskId: 'task_123',
+            taskTitle: 'Test Task',
+            completedBy: 'Test User',
+            completedAt: mockTask.completedAt,
+            timeSpent: 3600,
+            xpEarned: 50,
+          },
+        });
+      });
+
+      it('should return false if task has no assignedBy', async () => {
+        const taskWithoutAssigner = { ...mockTask, assignedBy: null };
+        const result = await NotificationService.notifyTaskCompleted(taskWithoutAssigner, mockUser);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('notifyTaskOverdue', () => {
+      it('should send task overdue notification', async () => {
+        const result = await NotificationService.notifyTaskOverdue(mockTask);
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0]).toMatchObject({
+          toUserId: 'partner_456',
+          type: NOTIFICATION_TYPES.TASK_OVERDUE,
+          data: {
+            taskId: 'task_123',
+            taskTitle: 'Test Task',
+            dueDate: mockTask.dueDate,
+          },
+        });
+      });
+
+      it('should return false if task has no assignedBy', async () => {
+        const taskWithoutAssigner = { ...mockTask, assignedBy: null };
+        const result = await NotificationService.notifyTaskOverdue(taskWithoutAssigner);
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('Social notification methods', () => {
+    beforeEach(() => {
+      UserStorageService.getUserById
+        .mockResolvedValueOnce(mockUser) // For fromUser lookup
+        .mockResolvedValueOnce(mockPartnerUser); // For toUser lookup
+    });
+
+    describe('sendEncouragement', () => {
+      it('should send encouragement notification', async () => {
+        const result = await NotificationService.sendEncouragement(
+          'user_123',
+          'partner_456',
+          'You can do it!',
+          'task_123',
+        );
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0]).toMatchObject({
+          toUserId: 'partner_456',
+          type: NOTIFICATION_TYPES.ENCOURAGEMENT,
+          data: {
+            message: 'You can do it!',
+            fromUser: 'Test User',
+            taskId: 'task_123',
+          },
+        });
+      });
+
+      it('should send encouragement without taskId', async () => {
+        const result = await NotificationService.sendEncouragement(
+          'user_123',
+          'partner_456',
+          'Keep going!',
+        );
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0].data.taskId).toBe(null);
+      });
+
+      it('should return false if fromUser not found', async () => {
+        UserStorageService.getUserById.mockReset();
+        UserStorageService.getUserById.mockResolvedValue(null);
+
+        const result = await NotificationService.sendEncouragement(
+          'unknown_user',
+          'partner_456',
+          'Message',
+        );
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('sendCheckIn', () => {
+      it('should send check-in notification', async () => {
+        const result = await NotificationService.sendCheckIn(
+          'user_123',
+          'partner_456',
+          'How are you doing today?',
+        );
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0]).toMatchObject({
+          toUserId: 'partner_456',
+          type: NOTIFICATION_TYPES.CHECK_IN,
+          data: {
+            message: 'How are you doing today?',
+            fromUser: 'Test User',
+          },
+        });
+      });
+
+      it('should return false if fromUser not found', async () => {
+        UserStorageService.getUserById.mockReset();
+        UserStorageService.getUserById.mockResolvedValue(null);
+
+        const result = await NotificationService.sendCheckIn(
+          'unknown_user',
+          'partner_456',
+          'Message',
+        );
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('Notification retrieval and management', () => {
+    beforeEach(() => {
+      NotificationService.pendingNotifications = [
+        { id: 'notif_1', toUserId: 'user_123', type: 'task_assigned', read: false },
+        { id: 'notif_2', toUserId: 'user_123', type: 'task_completed', read: true },
+        { id: 'notif_3', toUserId: 'partner_456', type: 'encouragement', read: false },
+        { id: 'notif_4', toUserId: 'user_123', type: 'check_in', read: false },
+      ];
+    });
+
+    describe('getNotificationsForUser', () => {
+      it('should return notifications for specific user', async () => {
+        const notifications = await NotificationService.getNotificationsForUser('user_123');
+
+        expect(notifications.length).toBe(3);
+        expect(notifications.every((n) => n.toUserId === 'user_123')).toBe(true);
+      });
+
+      it('should return empty array for user with no notifications', async () => {
+        const notifications = await NotificationService.getNotificationsForUser('unknown_user');
+
+        expect(notifications).toEqual([]);
+      });
+    });
+
+    describe('getUnreadNotificationCount', () => {
+      it('should return count of unread notifications', async () => {
+        const count = await NotificationService.getUnreadNotificationCount('user_123');
+
+        expect(count).toBe(2); // notif_1 and notif_4 are unread
+      });
+
+      it('should return 0 for user with no notifications', async () => {
+        const count = await NotificationService.getUnreadNotificationCount('unknown_user');
+
+        expect(count).toBe(0);
+      });
+    });
+
+    describe('markNotificationAsRead', () => {
+      it('should mark notification as read', async () => {
+        const result = await NotificationService.markNotificationAsRead('notif_1');
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications[0].read).toBe(true);
+        expect(AsyncStorage.setItem).toHaveBeenCalled();
+      });
+
+      it('should return false for non-existent notification', async () => {
+        const result = await NotificationService.markNotificationAsRead('notif_999');
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('markAllNotificationsAsRead', () => {
+      it('should mark all user notifications as read', async () => {
+        const result = await NotificationService.markAllNotificationsAsRead('user_123');
+
+        expect(result).toBe(true);
+
+        const userNotifications = NotificationService.pendingNotifications.filter(
+          (n) => n.toUserId === 'user_123',
+        );
+        expect(userNotifications.every((n) => n.read === true)).toBe(true);
+
+        // Partner notification should remain unread
+        const partnerNotification = NotificationService.pendingNotifications.find(
+          (n) => n.toUserId === 'partner_456',
+        );
+        expect(partnerNotification.read).toBe(false);
+
+        expect(AsyncStorage.setItem).toHaveBeenCalled();
+      });
+    });
+
+    describe('clearNotificationsForUser', () => {
+      it('should remove all notifications for user', async () => {
+        const result = await NotificationService.clearNotificationsForUser('user_123');
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications.length).toBe(1);
+        expect(NotificationService.pendingNotifications[0].toUserId).toBe('partner_456');
+        expect(AsyncStorage.setItem).toHaveBeenCalled();
+      });
+
+      it('should handle clearing for user with no notifications', async () => {
+        const result = await NotificationService.clearNotificationsForUser('unknown_user');
+
+        expect(result).toBe(true);
+        expect(NotificationService.pendingNotifications.length).toBe(4); // Unchanged
+      });
+    });
+  });
+});

--- a/src/services/__tests__/PartnershipService.test.js
+++ b/src/services/__tests__/PartnershipService.test.js
@@ -1,0 +1,667 @@
+// ABOUTME: Comprehensive unit tests for PartnershipService
+// Tests partnership creation, invites, status updates, and partnership operations
+
+import PartnershipService from '../PartnershipService';
+import SecureStorageService from '../SecureStorageService';
+import UserStorageService from '../UserStorageService';
+import {
+  createPartnership,
+  acceptPartnership,
+  updatePartnershipStats,
+} from '../../utils/PartnershipModel';
+import { setUserPartner } from '../../utils/UserModel';
+import { PARTNERSHIP_STATUS, USER_ROLE } from '../../constants/UserConstants';
+
+// Mock dependencies
+jest.mock('../SecureStorageService');
+jest.mock('../UserStorageService');
+jest.mock('../../utils/PartnershipModel');
+jest.mock('../../utils/UserModel');
+
+describe('PartnershipService', () => {
+  const mockPartnership = {
+    id: 'partnership_123',
+    adhdUserId: 'user_123',
+    partnerId: 'partner_456',
+    status: PARTNERSHIP_STATUS.ACTIVE,
+    inviteCode: 'ABC123',
+    inviteSentBy: 'user_123',
+    settings: {
+      allowTaskAssignment: true,
+      shareProgress: true,
+      allowEncouragement: true,
+      allowCheckIns: true,
+      quietHoursStart: null,
+      quietHoursEnd: null,
+    },
+    stats: {
+      tasksAssigned: 5,
+      tasksCompleted: 3,
+      encouragementsSent: 10,
+      checkInsCompleted: 2,
+      partnershipDuration: 7,
+    },
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-07'),
+    acceptedAt: new Date('2024-01-02'),
+    terminatedAt: null,
+  };
+
+  const mockPendingPartnership = {
+    ...mockPartnership,
+    id: 'partnership_pending',
+    status: PARTNERSHIP_STATUS.PENDING,
+    partnerId: null,
+    acceptedAt: null,
+  };
+
+  const mockUser = {
+    id: 'user_123',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: USER_ROLE.ADHD_USER,
+    partnerId: 'partner_456',
+  };
+
+  const mockPartner = {
+    id: 'partner_456',
+    name: 'Partner User',
+    email: 'partner@example.com',
+    role: USER_ROLE.PARTNER,
+    partnerId: 'user_123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    SecureStorageService.getItem.mockResolvedValue(null);
+    SecureStorageService.setItem.mockResolvedValue();
+    SecureStorageService.removeItem.mockResolvedValue();
+    UserStorageService.getUserById.mockResolvedValue(null);
+    UserStorageService.updateUser.mockResolvedValue(true);
+
+    // Mock partnership model functions
+    createPartnership.mockImplementation((data) => ({
+      ...mockPendingPartnership,
+      ...data,
+      id: `partnership_${Date.now()}`,
+      inviteCode: `CODE${Math.random().toString(36).substr(2, 3).toUpperCase()}`,
+    }));
+
+    acceptPartnership.mockImplementation((partnership) => ({
+      ...partnership,
+      status: PARTNERSHIP_STATUS.ACTIVE,
+      acceptedAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    updatePartnershipStats.mockImplementation((partnership, statUpdates) => ({
+      ...partnership,
+      stats: {
+        ...partnership.stats,
+        ...statUpdates,
+      },
+      updatedAt: new Date(),
+    }));
+
+    setUserPartner.mockImplementation((user, partnerId) => ({
+      ...user,
+      partnerId,
+      updatedAt: new Date(),
+    }));
+  });
+
+  describe('getAllPartnerships', () => {
+    it('should return all partnerships from storage', async () => {
+      const partnerships = [mockPartnership, mockPendingPartnership];
+      SecureStorageService.getItem.mockResolvedValue(partnerships);
+
+      const result = await PartnershipService.getAllPartnerships();
+
+      expect(SecureStorageService.getItem).toHaveBeenCalledWith('partnerships');
+      expect(result).toEqual(partnerships);
+    });
+
+    it('should return empty array if no partnerships', async () => {
+      SecureStorageService.getItem.mockResolvedValue(null);
+
+      const result = await PartnershipService.getAllPartnerships();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle non-array data gracefully', async () => {
+      SecureStorageService.getItem.mockResolvedValue('invalid');
+
+      const result = await PartnershipService.getAllPartnerships();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle storage errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.getItem.mockRejectedValue(new Error('Storage error'));
+
+      const result = await PartnershipService.getAllPartnerships();
+
+      expect(consoleError).toHaveBeenCalledWith('Error loading partnerships:', expect.any(Error));
+      expect(result).toEqual([]);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('savePartnership', () => {
+    it('should save new partnership to storage', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const newPartnership = { ...mockPendingPartnership, id: 'new_partnership' };
+      const result = await PartnershipService.savePartnership(newPartnership);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('partnerships', [
+        mockPartnership,
+        newPartnership,
+      ]);
+      expect(result).toBe(true);
+    });
+
+    it('should handle empty partnerships list', async () => {
+      SecureStorageService.getItem.mockResolvedValue([]);
+
+      const result = await PartnershipService.savePartnership(mockPartnership);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('partnerships', [mockPartnership]);
+      expect(result).toBe(true);
+    });
+
+    it('should handle save errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.setItem.mockRejectedValue(new Error('Save error'));
+
+      const result = await PartnershipService.savePartnership(mockPartnership);
+
+      expect(consoleError).toHaveBeenCalledWith('Error saving partnership:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('updatePartnership', () => {
+    it('should update existing partnership', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership, mockPendingPartnership]);
+
+      const updatedPartnership = {
+        ...mockPartnership,
+        stats: { ...mockPartnership.stats, tasksCompleted: 5 },
+      };
+      const result = await PartnershipService.updatePartnership(updatedPartnership);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('partnerships', [
+        updatedPartnership,
+        mockPendingPartnership,
+      ]);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if partnership not found', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const unknownPartnership = { ...mockPartnership, id: 'unknown_id' };
+      const result = await PartnershipService.updatePartnership(unknownPartnership);
+
+      expect(SecureStorageService.setItem).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should handle update errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // First getAllPartnerships succeeds
+      SecureStorageService.getItem.mockResolvedValueOnce([mockPartnership]);
+      // setItem fails
+      SecureStorageService.setItem.mockRejectedValue(new Error('Update error'));
+
+      const result = await PartnershipService.updatePartnership(mockPartnership);
+
+      expect(consoleError).toHaveBeenCalledWith('Error updating partnership:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('createPartnershipInvite', () => {
+    it('should create partnership invite for partner role', async () => {
+      SecureStorageService.getItem.mockResolvedValue([]);
+
+      const result = await PartnershipService.createPartnershipInvite('user_123', 'partner');
+
+      expect(createPartnership).toHaveBeenCalledWith({
+        inviteSentBy: 'user_123',
+        adhdUserId: 'user_123',
+        partnerId: null,
+      });
+      expect(SecureStorageService.setItem).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        inviteSentBy: 'user_123',
+        adhdUserId: 'user_123',
+      });
+    });
+
+    it('should create partnership invite for adhd_user role', async () => {
+      SecureStorageService.getItem.mockResolvedValue([]);
+
+      const result = await PartnershipService.createPartnershipInvite('partner_456', 'adhd_user');
+
+      expect(createPartnership).toHaveBeenCalledWith({
+        inviteSentBy: 'partner_456',
+        adhdUserId: null,
+        partnerId: 'partner_456',
+      });
+      expect(result).toMatchObject({
+        inviteSentBy: 'partner_456',
+        partnerId: 'partner_456',
+      });
+    });
+
+    it('should handle errors during invite creation', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // Mock createPartnership to throw an error
+      createPartnership.mockImplementation(() => {
+        throw new Error('Create error');
+      });
+
+      const result = await PartnershipService.createPartnershipInvite('user_123', 'partner');
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error creating partnership invite:',
+        expect.any(Error),
+      );
+      expect(result).toBeNull();
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('acceptPartnershipInvite', () => {
+    it('should accept valid partnership invite as ADHD user', async () => {
+      const pendingInvite = {
+        ...mockPendingPartnership,
+        adhdUserId: null,
+        partnerId: 'partner_456',
+      };
+      SecureStorageService.getItem.mockResolvedValue([pendingInvite]);
+      UserStorageService.getUserById
+        .mockResolvedValueOnce(mockUser) // ADHD user
+        .mockResolvedValueOnce(mockPartner); // Partner
+
+      const result = await PartnershipService.acceptPartnershipInvite('ABC123', 'user_123');
+
+      expect(result.success).toBe(true);
+      expect(result.partnership).toMatchObject({
+        adhdUserId: 'user_123',
+        partnerId: 'partner_456',
+        status: PARTNERSHIP_STATUS.ACTIVE,
+      });
+      expect(acceptPartnership).toHaveBeenCalled();
+      expect(setUserPartner).toHaveBeenCalledTimes(2);
+      expect(UserStorageService.updateUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('should accept valid partnership invite as partner', async () => {
+      const pendingInvite = {
+        ...mockPendingPartnership,
+        adhdUserId: 'user_123',
+        partnerId: null,
+      };
+      SecureStorageService.getItem.mockResolvedValue([pendingInvite]);
+      UserStorageService.getUserById
+        .mockResolvedValueOnce(mockUser) // ADHD user
+        .mockResolvedValueOnce(mockPartner); // Partner
+
+      const result = await PartnershipService.acceptPartnershipInvite('ABC123', 'partner_456');
+
+      expect(result.success).toBe(true);
+      expect(result.partnership).toMatchObject({
+        adhdUserId: 'user_123',
+        partnerId: 'partner_456',
+        status: PARTNERSHIP_STATUS.ACTIVE,
+      });
+    });
+
+    it('should reject invalid invite code', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.acceptPartnershipInvite('INVALID', 'user_123');
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Invalid invite code',
+      });
+    });
+
+    it('should reject already used invite', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]); // Already active
+
+      const result = await PartnershipService.acceptPartnershipInvite('ABC123', 'user_789');
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Invite already used',
+      });
+    });
+
+    it('should reject if partnership already complete', async () => {
+      const completePartnership = {
+        ...mockPendingPartnership,
+        adhdUserId: 'user_123',
+        partnerId: 'partner_456',
+      };
+      SecureStorageService.getItem.mockResolvedValue([completePartnership]);
+
+      const result = await PartnershipService.acceptPartnershipInvite('ABC123', 'user_789');
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Partnership already complete',
+      });
+    });
+
+    it('should handle errors during acceptance', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // First call succeeds to find the partnership
+      SecureStorageService.getItem.mockResolvedValueOnce([mockPendingPartnership]);
+      // acceptPartnership throws error
+      acceptPartnership.mockImplementation(() => {
+        throw new Error('Accept error');
+      });
+
+      const result = await PartnershipService.acceptPartnershipInvite('ABC123', 'user_123');
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error accepting partnership invite:',
+        expect.any(Error),
+      );
+      expect(result).toEqual({
+        success: false,
+        error: 'Failed to accept invite',
+      });
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getPartnershipByUsers', () => {
+    it('should find partnership by user IDs (order 1)', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership, mockPendingPartnership]);
+
+      const result = await PartnershipService.getPartnershipByUsers('user_123', 'partner_456');
+
+      expect(result).toEqual(mockPartnership);
+    });
+
+    it('should find partnership by user IDs (order 2)', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership, mockPendingPartnership]);
+
+      const result = await PartnershipService.getPartnershipByUsers('partner_456', 'user_123');
+
+      expect(result).toEqual(mockPartnership);
+    });
+
+    it('should return null if partnership not found', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.getPartnershipByUsers('user_123', 'unknown_user');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle errors from getAllPartnerships gracefully', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // When getAllPartnerships encounters an error, it returns empty array
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await PartnershipService.getPartnershipByUsers('user_123', 'partner_456');
+
+      // getAllPartnerships handles the error and returns [], so getPartnershipByUsers returns null
+      expect(consoleError).toHaveBeenCalledWith('Error loading partnerships:', expect.any(Error));
+      expect(result).toBeNull();
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getPartnershipByInviteCode', () => {
+    it('should find partnership by invite code', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership, mockPendingPartnership]);
+
+      const result = await PartnershipService.getPartnershipByInviteCode('ABC123');
+
+      expect(result).toEqual(mockPartnership);
+    });
+
+    it('should return null if invite code not found', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.getPartnershipByInviteCode('INVALID');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle errors from getAllPartnerships gracefully', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // When getAllPartnerships encounters an error, it returns empty array
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await PartnershipService.getPartnershipByInviteCode('ABC123');
+
+      // getAllPartnerships handles the error and returns [], so getPartnershipByInviteCode returns null
+      expect(consoleError).toHaveBeenCalledWith('Error loading partnerships:', expect.any(Error));
+      expect(result).toBeNull();
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getUserPartnerships', () => {
+    it('should return all partnerships for a user', async () => {
+      const anotherPartnership = {
+        ...mockPartnership,
+        id: 'partnership_other',
+        adhdUserId: 'user_123',
+        partnerId: 'partner_789',
+      };
+      SecureStorageService.getItem.mockResolvedValue([
+        mockPartnership,
+        mockPendingPartnership,
+        anotherPartnership,
+      ]);
+
+      const result = await PartnershipService.getUserPartnerships('user_123');
+
+      expect(result).toHaveLength(3);
+      expect(result).toContain(mockPartnership);
+      expect(result).toContain(mockPendingPartnership);
+      expect(result).toContain(anotherPartnership);
+    });
+
+    it('should return partnerships where user is partner', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership, mockPendingPartnership]);
+
+      const result = await PartnershipService.getUserPartnerships('partner_456');
+
+      expect(result).toHaveLength(1);
+      expect(result).toContain(mockPartnership);
+    });
+
+    it('should return empty array if no partnerships', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.getUserPartnerships('unknown_user');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle errors from getAllPartnerships gracefully', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // When getAllPartnerships encounters an error, it returns empty array
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await PartnershipService.getUserPartnerships('user_123');
+
+      // getAllPartnerships handles the error and returns [], so getUserPartnerships also returns []
+      expect(consoleError).toHaveBeenCalledWith('Error loading partnerships:', expect.any(Error));
+      expect(result).toEqual([]);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getActivePartnership', () => {
+    it('should return active partnership for user', async () => {
+      const pausedPartnership = {
+        ...mockPartnership,
+        id: 'partnership_paused',
+        status: PARTNERSHIP_STATUS.PAUSED,
+      };
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership, pausedPartnership]);
+
+      const result = await PartnershipService.getActivePartnership('user_123');
+
+      expect(result).toEqual(mockPartnership);
+    });
+
+    it('should return null if no active partnership', async () => {
+      const pausedPartnership = {
+        ...mockPartnership,
+        status: PARTNERSHIP_STATUS.PAUSED,
+      };
+      SecureStorageService.getItem.mockResolvedValue([pausedPartnership, mockPendingPartnership]);
+
+      const result = await PartnershipService.getActivePartnership('user_123');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle errors from getAllPartnerships gracefully', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // When getAllPartnerships encounters an error, it returns empty array
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await PartnershipService.getActivePartnership('user_123');
+
+      // getAllPartnerships handles the error and returns [], which leads to no active partnership
+      expect(consoleError).toHaveBeenCalledWith('Error loading partnerships:', expect.any(Error));
+      expect(result).toBeNull();
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('incrementPartnershipStat', () => {
+    it('should increment partnership stat by 1', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.incrementPartnershipStat(
+        'partnership_123',
+        'tasksCompleted',
+      );
+
+      expect(updatePartnershipStats).toHaveBeenCalledWith(mockPartnership, {
+        tasksCompleted: 4, // 3 + 1
+      });
+      expect(SecureStorageService.setItem).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('should increment partnership stat by custom amount', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.incrementPartnershipStat(
+        'partnership_123',
+        'encouragementsSent',
+        5,
+      );
+
+      expect(updatePartnershipStats).toHaveBeenCalledWith(mockPartnership, {
+        encouragementsSent: 15, // 10 + 5
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should handle missing stat gracefully', async () => {
+      const partnershipWithoutStat = {
+        ...mockPartnership,
+        stats: {},
+      };
+      SecureStorageService.getItem.mockResolvedValue([partnershipWithoutStat]);
+
+      const result = await PartnershipService.incrementPartnershipStat(
+        'partnership_123',
+        'newStat',
+      );
+
+      expect(updatePartnershipStats).toHaveBeenCalledWith(partnershipWithoutStat, {
+        newStat: 1, // 0 + 1
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return false if partnership not found', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnership]);
+
+      const result = await PartnershipService.incrementPartnershipStat(
+        'unknown_id',
+        'tasksCompleted',
+      );
+
+      expect(updatePartnershipStats).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should handle errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // First getAllPartnerships succeeds
+      SecureStorageService.getItem.mockResolvedValueOnce([mockPartnership]);
+      // updatePartnershipStats throws error
+      updatePartnershipStats.mockImplementation(() => {
+        throw new Error('Update stats error');
+      });
+
+      const result = await PartnershipService.incrementPartnershipStat(
+        'partnership_123',
+        'tasksCompleted',
+      );
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error incrementing partnership stat:',
+        expect.any(Error),
+      );
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('clearAllPartnerships', () => {
+    it('should clear all partnerships from storage', async () => {
+      const result = await PartnershipService.clearAllPartnerships();
+
+      expect(SecureStorageService.removeItem).toHaveBeenCalledWith('partnerships');
+      expect(result).toBe(true);
+    });
+
+    it('should handle clear errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.removeItem.mockRejectedValue(new Error('Clear error'));
+
+      const result = await PartnershipService.clearAllPartnerships();
+
+      expect(consoleError).toHaveBeenCalledWith('Error clearing partnerships:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+});

--- a/src/services/__tests__/UserStorageService.test.js
+++ b/src/services/__tests__/UserStorageService.test.js
@@ -1,0 +1,435 @@
+// ABOUTME: Comprehensive unit tests for UserStorageService
+// Tests user data persistence, authentication, and profile management
+
+import UserStorageService from '../UserStorageService';
+import SecureStorageService from '../SecureStorageService';
+import ErrorHandler from '../../utils/ErrorHandler';
+import { USER_ROLE } from '../../constants/UserConstants';
+
+// Mock dependencies
+jest.mock('../SecureStorageService');
+jest.mock('../../utils/ErrorHandler');
+jest.mock('react-native', () => ({
+  Alert: {
+    alert: jest.fn(),
+  },
+}));
+
+describe('UserStorageService', () => {
+  const mockUser = {
+    id: 'user_123',
+    email: 'test@example.com',
+    name: 'Test User',
+    role: USER_ROLE.ADHD_USER,
+    createdAt: new Date('2024-01-01'),
+  };
+
+  const mockPartnerUser = {
+    id: 'partner_456',
+    email: 'partner@example.com',
+    name: 'Partner User',
+    role: USER_ROLE.PARTNER,
+    createdAt: new Date('2024-01-02'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    SecureStorageService.getItem.mockResolvedValue(null);
+    SecureStorageService.setItem.mockResolvedValue();
+    SecureStorageService.removeItem.mockResolvedValue();
+    ErrorHandler.handleStorageError.mockImplementation(() => {});
+  });
+
+  describe('getCurrentUser', () => {
+    it('should return current user from secure storage', async () => {
+      SecureStorageService.getItem.mockResolvedValue(mockUser);
+
+      const result = await UserStorageService.getCurrentUser();
+
+      expect(SecureStorageService.getItem).toHaveBeenCalledWith('current_user');
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should return null if no current user', async () => {
+      SecureStorageService.getItem.mockResolvedValue(null);
+
+      const result = await UserStorageService.getCurrentUser();
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle storage errors gracefully', async () => {
+      SecureStorageService.getItem.mockRejectedValue(new Error('Storage error'));
+
+      const result = await UserStorageService.getCurrentUser();
+
+      expect(ErrorHandler.handleStorageError).toHaveBeenCalledWith(expect.any(Error), 'load');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setCurrentUser', () => {
+    it('should save current user to secure storage', async () => {
+      SecureStorageService.getItem.mockResolvedValue([]); // Empty users list
+
+      const result = await UserStorageService.setCurrentUser(mockUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('current_user', mockUser);
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [mockUser]);
+      expect(result).toBe(true);
+    });
+
+    it('should update user in all users list', async () => {
+      const existingUsers = [mockPartnerUser, { ...mockUser, name: 'Old Name' }];
+      SecureStorageService.getItem.mockResolvedValue(existingUsers);
+
+      const updatedUser = { ...mockUser, name: 'New Name' };
+      const result = await UserStorageService.setCurrentUser(updatedUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [
+        mockPartnerUser,
+        updatedUser,
+      ]);
+      expect(result).toBe(true);
+    });
+
+    it('should handle storage errors with retry', async () => {
+      SecureStorageService.setItem.mockRejectedValueOnce(new Error('Storage error'));
+
+      const result = await UserStorageService.setCurrentUser(mockUser);
+
+      expect(ErrorHandler.handleStorageError).toHaveBeenCalledWith(
+        expect.any(Error),
+        'save',
+        expect.any(Function),
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getAllUsers', () => {
+    it('should return all users from storage', async () => {
+      const users = [mockUser, mockPartnerUser];
+      SecureStorageService.getItem.mockResolvedValue(users);
+
+      const result = await UserStorageService.getAllUsers();
+
+      expect(SecureStorageService.getItem).toHaveBeenCalledWith('all_users');
+      expect(result).toEqual(users);
+    });
+
+    it('should return empty array if no users', async () => {
+      SecureStorageService.getItem.mockResolvedValue(null);
+
+      const result = await UserStorageService.getAllUsers();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle non-array data gracefully', async () => {
+      SecureStorageService.getItem.mockResolvedValue('invalid');
+
+      const result = await UserStorageService.getAllUsers();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle storage errors', async () => {
+      SecureStorageService.getItem.mockRejectedValue(new Error('Storage error'));
+
+      const result = await UserStorageService.getAllUsers();
+
+      expect(ErrorHandler.handleStorageError).toHaveBeenCalledWith(expect.any(Error), 'load');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('saveUser', () => {
+    it('should add new user to storage', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnerUser]);
+
+      const result = await UserStorageService.saveUser(mockUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [
+        mockPartnerUser,
+        mockUser,
+      ]);
+      expect(result).toBe(true);
+    });
+
+    it('should update existing user', async () => {
+      const oldUser = { ...mockUser, name: 'Old Name' };
+      SecureStorageService.getItem.mockResolvedValue([oldUser, mockPartnerUser]);
+
+      const updatedUser = { ...mockUser, name: 'New Name' };
+      const result = await UserStorageService.saveUser(updatedUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [
+        updatedUser,
+        mockPartnerUser,
+      ]);
+      expect(result).toBe(true);
+    });
+
+    it('should handle empty users list', async () => {
+      SecureStorageService.getItem.mockResolvedValue([]);
+
+      const result = await UserStorageService.saveUser(mockUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [mockUser]);
+      expect(result).toBe(true);
+    });
+
+    it('should handle save errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.setItem.mockRejectedValue(new Error('Save error'));
+
+      const result = await UserStorageService.saveUser(mockUser);
+
+      expect(consoleError).toHaveBeenCalledWith('Error saving user:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('updateUser', () => {
+    it('should update existing user in storage', async () => {
+      const oldUser = { ...mockUser, name: 'Old Name' };
+      SecureStorageService.getItem
+        .mockResolvedValueOnce([oldUser, mockPartnerUser]) // getAllUsers
+        .mockResolvedValueOnce(oldUser); // getCurrentUser
+
+      const updatedUser = { ...mockUser, name: 'New Name' };
+      const result = await UserStorageService.updateUser(updatedUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [
+        updatedUser,
+        mockPartnerUser,
+      ]);
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('current_user', updatedUser);
+      expect(result).toBe(true);
+    });
+
+    it('should save as new user if not found', async () => {
+      SecureStorageService.getItem
+        .mockResolvedValueOnce([mockPartnerUser]) // getAllUsers
+        .mockResolvedValueOnce([mockPartnerUser]); // getAllUsers in saveUser
+
+      const result = await UserStorageService.updateUser(mockUser);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [
+        mockPartnerUser,
+        mockUser,
+      ]);
+      expect(result).toBe(true);
+    });
+
+    it('should not update current user if different', async () => {
+      SecureStorageService.getItem
+        .mockResolvedValueOnce([mockUser, mockPartnerUser]) // getAllUsers
+        .mockResolvedValueOnce(mockUser); // getCurrentUser
+
+      const updatedPartner = { ...mockPartnerUser, name: 'Updated Partner' };
+      const result = await UserStorageService.updateUser(updatedPartner);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('all_users', [
+        mockUser,
+        updatedPartner,
+      ]);
+      expect(SecureStorageService.setItem).not.toHaveBeenCalledWith('current_user', updatedPartner);
+      expect(result).toBe(true);
+    });
+
+    it('should handle update errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      // First getAllUsers call succeeds
+      SecureStorageService.getItem.mockResolvedValueOnce([mockUser, mockPartnerUser]);
+      // setItem fails
+      SecureStorageService.setItem.mockRejectedValue(new Error('Update error'));
+
+      const result = await UserStorageService.updateUser(mockUser);
+
+      expect(consoleError).toHaveBeenCalledWith('Error updating user:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getUserById', () => {
+    it('should find user by ID', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockUser, mockPartnerUser]);
+
+      const result = await UserStorageService.getUserById('user_123');
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should return null if user not found', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockPartnerUser]);
+
+      const result = await UserStorageService.getUserById('unknown_id');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle empty users list', async () => {
+      SecureStorageService.getItem.mockResolvedValue([]);
+
+      const result = await UserStorageService.getUserById('user_123');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle errors from getAllUsers gracefully', async () => {
+      // When getAllUsers encounters an error, it returns empty array
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await UserStorageService.getUserById('user_123');
+
+      // getAllUsers handles the error and returns [], so getUserById returns null
+      expect(ErrorHandler.handleStorageError).toHaveBeenCalledWith(expect.any(Error), 'load');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUserByEmail', () => {
+    it('should find user by email', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockUser, mockPartnerUser]);
+
+      const result = await UserStorageService.getUserByEmail('test@example.com');
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should be case-insensitive', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockUser, mockPartnerUser]);
+
+      const result = await UserStorageService.getUserByEmail('TEST@EXAMPLE.COM');
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should return null if user not found', async () => {
+      SecureStorageService.getItem.mockResolvedValue([mockUser, mockPartnerUser]);
+
+      const result = await UserStorageService.getUserByEmail('unknown@example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle errors from getAllUsers gracefully', async () => {
+      // When getAllUsers encounters an error, it returns empty array
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await UserStorageService.getUserByEmail('test@example.com');
+
+      // getAllUsers handles the error and returns [], so getUserByEmail returns null
+      expect(ErrorHandler.handleStorageError).toHaveBeenCalledWith(expect.any(Error), 'load');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear current user and token', async () => {
+      const result = await UserStorageService.logout();
+
+      expect(SecureStorageService.removeItem).toHaveBeenCalledWith('current_user');
+      expect(SecureStorageService.removeItem).toHaveBeenCalledWith('user_token');
+      expect(result).toBe(true);
+    });
+
+    it('should handle logout errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.removeItem.mockRejectedValue(new Error('Remove error'));
+
+      const result = await UserStorageService.logout();
+
+      expect(consoleError).toHaveBeenCalledWith('Error during logout:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('saveUserToken', () => {
+    it('should save user token to secure storage', async () => {
+      const token = 'mock_token_123';
+      const result = await UserStorageService.saveUserToken(token);
+
+      expect(SecureStorageService.setItem).toHaveBeenCalledWith('user_token', token);
+      expect(result).toBe(true);
+    });
+
+    it('should handle save token errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.setItem.mockRejectedValue(new Error('Save error'));
+
+      const result = await UserStorageService.saveUserToken('token');
+
+      expect(consoleError).toHaveBeenCalledWith('Error saving user token:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('getUserToken', () => {
+    it('should get user token from secure storage', async () => {
+      const token = 'mock_token_123';
+      SecureStorageService.getItem.mockResolvedValue(token);
+
+      const result = await UserStorageService.getUserToken();
+
+      expect(SecureStorageService.getItem).toHaveBeenCalledWith('user_token');
+      expect(result).toBe(token);
+    });
+
+    it('should return null if no token', async () => {
+      SecureStorageService.getItem.mockResolvedValue(null);
+
+      const result = await UserStorageService.getUserToken();
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle get token errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.getItem.mockRejectedValue(new Error('Get error'));
+
+      const result = await UserStorageService.getUserToken();
+
+      expect(consoleError).toHaveBeenCalledWith('Error getting user token:', expect.any(Error));
+      expect(result).toBeNull();
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('clearAllUsers', () => {
+    it('should clear all user data', async () => {
+      const result = await UserStorageService.clearAllUsers();
+
+      expect(SecureStorageService.removeItem).toHaveBeenCalledWith('all_users');
+      expect(SecureStorageService.removeItem).toHaveBeenCalledWith('current_user');
+      expect(SecureStorageService.removeItem).toHaveBeenCalledWith('user_token');
+      expect(SecureStorageService.removeItem).toHaveBeenCalledTimes(3);
+      expect(result).toBe(true);
+    });
+
+    it('should handle clear errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+      SecureStorageService.removeItem.mockRejectedValue(new Error('Remove error'));
+
+      const result = await UserStorageService.clearAllUsers();
+
+      expect(consoleError).toHaveBeenCalledWith('Error clearing users:', expect.any(Error));
+      expect(result).toBe(false);
+
+      consoleError.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added 110 unit tests for critical services that were missing test coverage
- Achieved >80% test coverage for all services (82.42% overall)
- Fixed missing dependencies for test setup

## What Changed
### Test Coverage Added
- **NotificationService**: 35 tests, 100% coverage
- **UserStorageService**: 35 tests, 93.67% coverage  
- **PartnershipService**: 40 tests, 91.83% coverage

### Dependencies Fixed
- Added missing `expo-modules-core` dependency
- Updated `react-test-renderer` to version 19.1.0 to match React version

## Test Results
All new tests are passing. The critical services that handle:
- User notifications between accountability partners
- User data persistence and authentication
- Partnership management between ADHD users and partners

...are now thoroughly tested with comprehensive unit tests covering all functionality including error cases.

## Impact
This addresses the critical technical debt identified in issue #12 where core services had zero test coverage. With proper test coverage in place:
- ✅ Confidence in refactoring
- ✅ Bugs detected early
- ✅ Features protected from regressions
- ✅ TDD requirements satisfied

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)