### PR TITLE
Fix timer helper functions timeout in asyncHelpers tests

### DIFF
--- a/src/screens/NotificationListScreen.tsx
+++ b/src/screens/NotificationListScreen.tsx
@@ -125,9 +125,9 @@ const NotificationListScreen: React.FC = () => {
     }
   };
 
-  const getTimeAgo = (timestamp: string): string => {
+  const getTimeAgo = (timestamp: string | Date): string => {
     const now = new Date();
-    const notificationTime = new Date(timestamp);
+    const notificationTime = timestamp instanceof Date ? timestamp : new Date(timestamp);
     const diffMs = now.getTime() - notificationTime.getTime();
     const diffMins = Math.floor(diffMs / 60000);
     const diffHours = Math.floor(diffMs / 3600000);
@@ -152,7 +152,7 @@ const NotificationListScreen: React.FC = () => {
             markAsRead(item.id);
           }
           // Navigate to relevant screen based on notification type
-          if ((item as any).data?.taskId) {
+          if (item.data?.taskId) {
             // Navigate to task list
             navigation.navigate('TaskList');
           }

--- a/tests/utils/asyncHelpers.js
+++ b/tests/utils/asyncHelpers.js
@@ -122,7 +122,6 @@ export const mockAsyncStorage = (initialData = {}) => {
 export const advanceTimersAndWait = async (ms) => {
   await act(async () => {
     jest.advanceTimersByTime(ms);
-    await waitForAsyncUpdates();
   });
 };
 
@@ -133,7 +132,6 @@ export const advanceTimersAndWait = async (ms) => {
 export const runAllTimersAndWait = async () => {
   await act(async () => {
     jest.runAllTimers();
-    await waitForAsyncUpdates();
   });
 };
 


### PR DESCRIPTION
## Summary
- Fixed timeout issues in asyncHelpers timer tests by removing conflicting waitForAsyncUpdates calls
- Fixed TypeScript error in NotificationListScreen by updating getTimeAgo to handle both string and Date types

## Details

This PR addresses part of issue #37 by fixing failing timer tests in the asyncHelpers test suite. The tests were timing out because `waitForAsyncUpdates` uses `setTimeout` which doesn't work properly when Jest's fake timers are enabled.

### Changes made:
1. Removed `waitForAsyncUpdates` calls from `advanceTimersAndWait` and `runAllTimersAndWait` functions
2. Fixed TypeScript error in NotificationListScreen where `getTimeAgo` wasn't handling the union type `string  < /dev/null |  Date`
3. Removed unnecessary type casting in NotificationListScreen

## Test Results
All asyncHelpers tests now pass:
- ✅ 19 tests passed
- ✅ No timeouts
- ✅ TypeScript compilation successful

## Related Issues
Closes #37 (partially - fixes one specific test failure)

🤖 Generated with [Claude Code](https://claude.ai/code)