### PR TITLE
fix: Add missing expo-linking dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo": "~53.0.9",
         "expo-crypto": "~14.1.4",
         "expo-haptics": "^14.1.4",
+        "expo-linking": "^7.1.5",
         "expo-local-authentication": "~16.0.4",
         "expo-router": "~5.0.7",
         "expo-secure-store": "^14.2.3",
@@ -7314,6 +7315,19 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linking": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-7.1.5.tgz",
+      "integrity": "sha512-8g20zOpROW78bF+bLI4a3ZWj4ntLgM0rCewKycPL0jk9WGvBrBtFtwwADJgOiV1EurNp3lcquerXGlWS+SOQyA==",
+      "dependencies": {
+        "expo-constants": "~17.1.6",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-local-authentication": {

--- a/package.json
+++ b/package.json
@@ -40,15 +40,16 @@
     "expo": "~53.0.9",
     "expo-crypto": "~14.1.4",
     "expo-haptics": "^14.1.4",
+    "expo-linking": "^7.1.5",
+    "expo-local-authentication": "~16.0.4",
+    "expo-router": "~5.0.7",
     "expo-secure-store": "^14.2.3",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
-    "expo-router": "~5.0.7",
-    "expo-local-authentication": "~16.0.4"
+    "react-native-screens": "~4.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- Adds expo-linking@7.1.5 as a dependency to fix iOS bundling error
- Resolves issue where expo-router couldn't find expo-linking module

## Problem
The app was failing to bundle on iOS with the error:
```
Unable to resolve "expo-linking" from "node_modules\expo-router\build\global-state\routing.js"
```

## Solution
Added expo-linking as a direct dependency. This package is required by expo-router v5 but was not automatically installed.

## Testing
- [x] Verified package installation completes successfully
- [x] Confirmed expo-router peer dependency is satisfied

Fixes #78