### PR TITLE
fix: Phase 3 - Migrate contexts to use ErrorHandler utility

### DIFF
--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -15,6 +15,7 @@ import NotificationService from '../services/NotificationService';
 import type { Notification } from '../types/notification.types';
 import { NotificationTypes } from '../types/user.types';
 import { supabase } from '../services/SupabaseService';
+import { logError } from '../utils/ErrorHandler';
 
 interface NotificationContextValue {
   notifications: Notification[];
@@ -90,7 +91,7 @@ export const NotificationProvider = ({ children }: NotificationProviderProps) =>
     } catch (err) {
       if (isMountedRef.current) {
         setError((err as Error).message);
-        console.error('Error loading notifications:', err);
+        logError('NotificationContext.loadNotifications', err);
       }
     } finally {
       if (isMountedRef.current) {
@@ -157,7 +158,7 @@ export const NotificationProvider = ({ children }: NotificationProviderProps) =>
         // Real-time subscription will handle adding to state
       } catch (err) {
         setError((err as Error).message);
-        console.error('Error adding notification:', err);
+        logError('NotificationContext.addNotification', err);
         throw err;
       }
     },
@@ -178,7 +179,7 @@ export const NotificationProvider = ({ children }: NotificationProviderProps) =>
       }
     } catch (err) {
       setError((err as Error).message);
-      console.error('Error marking notification as read:', err);
+      logError('NotificationContext.markAsRead', err);
       throw err;
     }
   }, []);
@@ -197,7 +198,7 @@ export const NotificationProvider = ({ children }: NotificationProviderProps) =>
       }
     } catch (err) {
       setError((err as Error).message);
-      console.error('Error marking all notifications as read:', err);
+      logError('NotificationContext.markAllAsRead', err);
       throw err;
     }
   }, [currentUser?.id]);
@@ -213,7 +214,7 @@ export const NotificationProvider = ({ children }: NotificationProviderProps) =>
         setNotifications((prev) => prev.filter((n) => n.id !== notificationId));
       } catch (err) {
         setError((err as Error).message);
-        console.error('Error deleting notification:', err);
+        logError('NotificationContext.deleteNotification', err);
         throw err;
       }
     });
@@ -233,7 +234,7 @@ export const NotificationProvider = ({ children }: NotificationProviderProps) =>
       }
     } catch (err) {
       setError((err as Error).message);
-      console.error('Error clearing notifications:', err);
+      logError('NotificationContext.clearAllNotifications', err);
       throw err;
     }
   }, [currentUser?.id]);

--- a/src/contexts/PresenceContext.tsx
+++ b/src/contexts/PresenceContext.tsx
@@ -6,6 +6,7 @@ import { AppState } from 'react-native';
 import type { PresenceState } from '../services/PresenceService';
 import PresenceService from '../services/PresenceService';
 import { useUser } from './UserContext';
+import { logError } from '../utils/ErrorHandler';
 
 interface PresenceContextType {
   presenceStates: Map<string, PresenceState>;
@@ -46,7 +47,7 @@ export const PresenceProvider: React.FC<PresenceProviderProps> = ({ children }) 
           setMyPresence(PresenceService.getPresenceState(user.id) ?? null);
         }, 5000); // Update every 5 seconds
       } catch (error) {
-        console.error('Error initializing presence:', error);
+        logError('PresenceContext.initializePresence', error);
       }
     };
 

--- a/src/contexts/TaskContext.tsx
+++ b/src/contexts/TaskContext.tsx
@@ -15,6 +15,7 @@ import TaskStorageService from '../services/TaskStorageService';
 import type { Task } from '../types/task.types';
 import { TaskStatus, TaskPriority } from '../types/task.types';
 import { supabase } from '../services/SupabaseService';
+import { logError } from '../utils/ErrorHandler';
 
 // Define the context value interface
 interface TaskContextValue {
@@ -83,7 +84,7 @@ export const TaskProvider = ({ children }: TaskProviderProps) => {
     } catch (err) {
       if (isMountedRef.current) {
         setError((err as Error).message);
-        console.error('Error loading tasks:', err);
+        logError('TaskContext.loadTasks', err);
       }
     } finally {
       if (isMountedRef.current) {
@@ -217,7 +218,7 @@ export const TaskProvider = ({ children }: TaskProviderProps) => {
         // Real-time subscription will handle adding to state
       } catch (err) {
         setError((err as Error).message);
-        console.error('Error adding task:', err);
+        logError('TaskContext.addTask', err);
         throw err;
       }
     },
@@ -245,7 +246,7 @@ export const TaskProvider = ({ children }: TaskProviderProps) => {
         // Real-time subscription will handle updating state
       } catch (err) {
         setError((err as Error).message);
-        console.error('Error updating task:', err);
+        logError('TaskContext.updateTask', err);
         throw err;
       }
     },
@@ -261,7 +262,7 @@ export const TaskProvider = ({ children }: TaskProviderProps) => {
       // Real-time subscription will handle removing from state
     } catch (err) {
       setError((err as Error).message);
-      console.error('Error deleting task:', err);
+      logError('TaskContext.deleteTask', err);
       throw err;
     }
   }, []);

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -15,6 +15,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import AuthService from '../services/AuthService';
 import UserStorageService from '../services/UserStorageService';
 import type { User, Partnership } from '../types/user.types';
+import { logError } from '../utils/ErrorHandler';
 
 interface UserContextValue {
   user: User | null;
@@ -78,7 +79,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
-      console.error('Error loading user data:', err);
+      logError('UserContext.loadUserData', err);
     } finally {
       setLoading(false);
     }
@@ -168,7 +169,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
-      console.error('Error updating user:', err);
+      logError('UserContext.updateUser', err);
     }
   }, []);
 
@@ -182,7 +183,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred');
-        console.error('Error updating partner:', err);
+        logError('UserContext.setPartnerData', err);
       }
     },
     [user],
@@ -198,7 +199,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred');
-        console.error('Error updating partnership:', err);
+        logError('UserContext.setPartnershipData', err);
       }
     },
     [user],
@@ -228,7 +229,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       setPartnership(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
-      console.error('Error during logout:', err);
+      logError('UserContext.logout', err);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
This PR completes Phase 3 of issue #149 by migrating all 5 context files to use the centralized ErrorHandler utility instead of direct console.error calls.

## Changes
- ✅ **TaskContext.tsx**: Replaced 4 console.error calls with logError
- ✅ **UserContext.tsx**: Replaced 5 console.error calls with logError  
- ✅ **NotificationContext.tsx**: Replaced 6 console.error calls with logError
- ✅ **PresenceContext.tsx**: Replaced 1 console.error call with logError
- ✅ **CollaborativeEditingContext.tsx**: Already uses SecureLogger (no changes needed)

## Migration Pattern
All instances of:
```typescript
console.error('Error message:', error);
```

Were replaced with:
```typescript
import { logError } from '../utils/ErrorHandler';
// ...
logError('ContextName.methodName', error);
```

## Testing
- ✅ ESLint passes with no issues
- ✅ TypeScript checks pass  
- ✅ No console.error patterns remain in context source files
- ✅ Pre-commit hooks passed

## Related Issues
- Fixes Phase 3 of #149

## Next Steps
After this PR is merged, Phase 4 can begin to migrate the remaining 6 component files listed in issue #149.

🤖 Generated with [Claude Code](https://claude.ai/code)